### PR TITLE
Add support for GBA display mode 0 (tiled) and basic square wave sound (channel 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ func update() {
 ## Roadmap
 
 - [ ] Display Control (https://problemkaputt.de/gbatek.htm#lcdvramoverview)
-	- [ ] BG Mode 0
+	- [X] BG Mode 0
 	- [ ] BG Mode 1
 	- [ ] BG Mode 2
 	- [X] BG Mode 3
@@ -94,5 +94,10 @@ func update() {
 - [ ] Pallettes (https://problemkaputt.de/gbatek.htm#lcdcolorpalettes)
 
 - [ ] Sound (https://problemkaputt.de/gbatek.htm#gbasoundcontroller)
+	- [ ] Sound Channel 1
+	- [X] Sound Channel 2
+	- [ ] Sound Channel 3
+	- [ ] Sound Channel 4
+	- [ ] Sound Channel DMA
 
 - [ ] Interrupts (https://problemkaputt.de/gbatek.htm#gbainterruptcontrol)

--- a/examples/tiled_keyboard_with_sound/keyboard.go
+++ b/examples/tiled_keyboard_with_sound/keyboard.go
@@ -1,0 +1,299 @@
+package main
+
+// Tile-based keyboard rendering using the tiles package (GBA Mode 0).
+//
+// Layout (one tile = 8×8 px; each key = 2×2 tiles = 16×16 px, no gap):
+//
+//	Row 0 (10 keys "qwertyuiop"): tile x 5–24, tile y 13–14
+//	Row 1 ( 9 keys "asdfghjkl"): tile x 6–23, tile y 15–16
+//	Row 2 ( 7 keys "zxcvbnm"):    tile x 8–21, tile y 17–18
+//
+// VRAM layout (character block 0, 4bpp):
+//
+//	Tile  0         — transparent (blank)
+//	Tile  1         — solid gray  (normal key background)
+//	Tile  2         — solid purple (selected key background)
+//	Tiles 10–113   — letter glyph quarters, 4 per letter (a–z)
+//	                  letter i → tiles 10+i*4 .. 10+i*4+3
+//	                  (top-left, top-right, bottom-left, bottom-right)
+//
+// Screen blocks (each 2 KB):
+//
+//	Block 8 → BG1 tilemap — colored key backgrounds
+//	Block 9 → BG0 tilemap — letter overlays (transparent bg)
+//
+// Centering: each 5×7 glyph is placed at key-relative pixel (5, 4), so it
+// straddles all four 8×8 tiles of the 2×2 key block:
+//
+//	Key cols 5–7  → left tiles  (tile-cols 5,6,7)
+//	Key cols 8–9  → right tiles (tile-cols 0,1)
+//	Key rows 4–7  → top tiles   (tile-rows 4,5,6,7)
+//	Key rows 8–10 → bottom tiles (tile-rows 0,1,2)
+
+import (
+	"tinygo.org/x/tinygba"
+)
+
+// Keyboard layout: three QWERTY rows.
+var layout = [][]string{
+	{"q", "w", "e", "r", "t", "y", "u", "i", "o", "p"},
+	{"a", "s", "d", "f", "g", "h", "j", "k", "l"},
+	{"z", "x", "c", "v", "b", "n", "m"},
+}
+
+// Cursor state.
+var (
+	selectedRow        = 0
+	selectedCol        = 0
+	prevButtons uint16 = 0xFFFF // all bits high = no buttons pressed (GBA active-low)
+)
+
+// VRAM / tilemap constants.
+const (
+	kbCharBlock    uint8  = 0  // character block holding tile pixel data
+	kbBgBlock      uint8  = 8  // screen block for BG1 (key backgrounds)
+	kbFgBlock      uint8  = 9  // screen block for BG0 (letter glyphs)
+	tileKeyNormal  uint16 = 1  // solid gray
+	tileKeySelect  uint16 = 2  // solid highlight
+	tileLetterBase        = 10 // first tile index for letter quarters
+)
+
+// Palette color indices (all in palette 0).
+const (
+	palKeyGray = 1 // normal key background
+	palKeyHL   = 2 // selected key background
+	palLetter  = 3 // letter glyph pixels
+)
+
+// Keyboard tile Y-rows: row r starts at tile row (13 + r*2).
+const kbTileY0 = 13
+
+// keyTileX returns the leftmost tile X for the key at (row, col).
+func keyTileX(row, col int) uint8 {
+	switch row {
+	case 0:
+		return uint8(5 + col*2) // 10 keys → tiles 5–24
+	case 1:
+		return uint8(6 + col*2) // 9 keys → tiles 6–23
+	default:
+		return uint8(8 + col*2) // 7 keys → tiles 8–21
+	}
+}
+
+// keyTileY returns the top tile Y for keyboard row r.
+func keyTileY(row int) uint8 { return uint8(kbTileY0 + row*2) }
+
+// prevTileRow / prevTileCol track which key was last highlighted.
+var prevTileRow, prevTileCol = -1, -1
+
+// justPressed returns true only on the frame a button transitions from released to pressed.
+func justPressed(button tinygba.Button, curr, prev uint16) bool {
+	return button.IsPushed(curr) && !button.IsPushed(prev)
+}
+
+// InitTiles sets up the display (Mode 0), palette, tile pixel data, and the
+// initial tilemap. Call once at startup in place of machine.Display.Configure().
+func InitTiles() {
+	// Enable Mode 0 with BG0 (letters, front) and BG1 (backgrounds, back).
+	tinygba.ConfigureLayers(tinygba.Layer0, tinygba.Layer1)
+	tinygba.SetupLayer(tinygba.Layer1, kbCharBlock, kbBgBlock, tinygba.Colors16, tinygba.Size32x32, 1)
+	tinygba.SetupLayer(tinygba.Layer0, kbCharBlock, kbFgBlock, tinygba.Colors16, tinygba.Size32x32, 0)
+	tinygba.SetScroll(tinygba.Layer0, 0, 0)
+	tinygba.SetScroll(tinygba.Layer1, 0, 0)
+
+	// Palette 0:
+	//   index 0 — transparent / backdrop (left as black)
+	//   index 1 — normal key gray
+	//   index 2 — selected key purple
+	//   index 3 — letter white
+	tinygba.SetPaletteColor(0, palKeyGray, tinygba.RGB(12, 12, 12))
+	tinygba.SetPaletteColor(0, palKeyHL, tinygba.RGB(14, 8, 20))
+	tinygba.SetPaletteColor(0, palLetter, tinygba.RGB(31, 31, 31))
+
+	// Tile 1: solid gray (all pixels = palette index 1).
+	var solid [32]byte
+	for i := range solid {
+		solid[i] = palKeyGray | (palKeyGray << 4)
+	}
+	tinygba.DefineTile4bpp(kbCharBlock, tileKeyNormal, solid)
+
+	// Tile 2: solid highlight (all pixels = palette index 2).
+	for i := range solid {
+		solid[i] = palKeyHL | (palKeyHL << 4)
+	}
+	tinygba.DefineTile4bpp(kbCharBlock, tileKeySelect, solid)
+
+	// Tiles 10–113: four quarter-tiles per letter (a–z).
+	for i, rows := range letterGlyphs {
+		tl, tr, bl, br := glyphQuarterTiles(rows)
+		base := uint16(tileLetterBase + i*4)
+		tinygba.DefineTile4bpp(kbCharBlock, base+0, tl)
+		tinygba.DefineTile4bpp(kbCharBlock, base+1, tr)
+		tinygba.DefineTile4bpp(kbCharBlock, base+2, bl)
+		tinygba.DefineTile4bpp(kbCharBlock, base+3, br)
+	}
+
+	// Clear both screen blocks to tile 0 (transparent).
+	tinygba.FillTiled(kbBgBlock, 0, 0, 30, 20, 0, 0)
+	tinygba.FillTiled(kbFgBlock, 0, 0, 30, 20, 0, 0)
+
+	// Write background tiles for every key (all normal to start).
+	for row, rowKeys := range layout {
+		for col := range rowKeys {
+			setKeyBg(row, col, tileKeyNormal)
+		}
+	}
+	// Write the four letter quarter-tiles for each key into BG0.
+	setLetterTiles()
+
+	// Highlight the initial selection.
+	setKeyBg(selectedRow, selectedCol, tileKeySelect)
+	prevTileRow, prevTileCol = selectedRow, selectedCol
+}
+
+// DrawTile updates only the tiles that changed due to a new key selection.
+// Call every frame after UpdateTiledMode has run.
+func DrawTile() {
+	if selectedRow == prevTileRow && selectedCol == prevTileCol {
+		return
+	}
+	setKeyBg(prevTileRow, prevTileCol, tileKeyNormal)
+	setKeyBg(selectedRow, selectedCol, tileKeySelect)
+	prevTileRow, prevTileCol = selectedRow, selectedCol
+}
+
+// Update handles input and navigates the keyboard in tile mode.
+// Call every frame before DrawTile.
+func Update() {
+	curr := tinygba.ReadButtons()
+
+	var playBeep bool
+
+	switch {
+	case justPressed(tinygba.ButtonRight, curr, prevButtons):
+		selectedCol++
+		if selectedCol >= len(layout[selectedRow]) {
+			selectedCol = 0
+		}
+		playBeep = true
+	case justPressed(tinygba.ButtonLeft, curr, prevButtons):
+		selectedCol--
+		if selectedCol < 0 {
+			selectedCol = len(layout[selectedRow]) - 1
+		}
+		playBeep = true
+	case justPressed(tinygba.ButtonDown, curr, prevButtons):
+		selectedRow++
+		if selectedRow >= len(layout) {
+			selectedRow = 0
+		}
+		if selectedCol >= len(layout[selectedRow]) {
+			selectedCol = len(layout[selectedRow]) - 1
+		}
+		playBeep = true
+	case justPressed(tinygba.ButtonUp, curr, prevButtons):
+		selectedRow--
+		if selectedRow < 0 {
+			selectedRow = len(layout) - 1
+		}
+		if selectedCol >= len(layout[selectedRow]) {
+			selectedCol = len(layout[selectedRow]) - 1
+		}
+		playBeep = true
+	}
+
+	if playBeep {
+		tinygba.PlayNote(1800, 0, 6, 57)
+	}
+
+	prevButtons = curr
+}
+
+// setKeyBg writes the 2×2 BG1 background tiles for one key.
+func setKeyBg(row, col int, tile uint16) {
+	x := keyTileX(row, col)
+	y := keyTileY(row)
+	tinygba.SetTile(kbBgBlock, x, y, tile, 0, false, false)
+	tinygba.SetTile(kbBgBlock, x+1, y, tile, 0, false, false)
+	tinygba.SetTile(kbBgBlock, x, y+1, tile, 0, false, false)
+	tinygba.SetTile(kbBgBlock, x+1, y+1, tile, 0, false, false)
+}
+
+// setLetterTiles writes the four quarter-tiles for each key's letter into BG0.
+func setLetterTiles() {
+	for row, rowKeys := range layout {
+		for col, key := range rowKeys {
+			letterIdx := int(key[0] - 'a') // 'a'→0, 'z'→25
+			x := keyTileX(row, col)
+			y := keyTileY(row)
+			base := uint16(tileLetterBase + letterIdx*4)
+			tinygba.SetTile(kbFgBlock, x, y, base+0, 0, false, false)
+			tinygba.SetTile(kbFgBlock, x+1, y, base+1, 0, false, false)
+			tinygba.SetTile(kbFgBlock, x, y+1, base+2, 0, false, false)
+			tinygba.SetTile(kbFgBlock, x+1, y+1, base+3, 0, false, false)
+		}
+	}
+}
+
+// glyphQuarterTiles splits a centered 5×7 glyph across the four 8×8 tiles of
+// a 2×2 key block, returning (top-left, top-right, bottom-left, bottom-right).
+func glyphQuarterTiles(rows [7]uint8) (tl, tr, bl, br [32]byte) {
+	for gr := 0; gr < 7; gr++ {
+		bits := rows[gr]
+		var g [5]uint8
+		for i := range g {
+			if (bits>>(4-uint(i)))&1 != 0 {
+				g[i] = palLetter
+			}
+		}
+		var tileRow int
+		if gr < 4 {
+			tileRow = 4 + gr
+		} else {
+			tileRow = gr - 4
+		}
+		base := tileRow * 4
+		if gr < 4 {
+			tl[base+2] = 0 | (g[0] << 4)
+			tl[base+3] = g[1] | (g[2] << 4)
+			tr[base+0] = g[3] | (g[4] << 4)
+		} else {
+			bl[base+2] = 0 | (g[0] << 4)
+			bl[base+3] = g[1] | (g[2] << 4)
+			br[base+0] = g[3] | (g[4] << 4)
+		}
+	}
+	return
+}
+
+// letterGlyphs holds 5×7 pixel bitmaps for 'a'–'z' (indices 0–25).
+// Each [7]uint8 is seven rows; each uint8's lower 5 bits are the row pixels
+// (bit 4 = leftmost column, bit 0 = rightmost column).
+var letterGlyphs = [26][7]uint8{
+	{14, 17, 17, 31, 17, 17, 17}, // a  .###. #...# #...# ##### #...# #...# #...#
+	{30, 17, 17, 30, 17, 17, 30}, // b  ####. #...# #...# ####. #...# #...# ####.
+	{14, 17, 16, 16, 16, 17, 14}, // c  .###. #...# #.... #.... #.... #...# .###.
+	{30, 17, 17, 17, 17, 17, 30}, // d  ####. #...# #...# #...# #...# #...# ####.
+	{31, 16, 16, 30, 16, 16, 31}, // e  ##### #.... #.... ####. #.... #.... #####
+	{31, 16, 16, 30, 16, 16, 16}, // f  ##### #.... #.... ####. #.... #.... #....
+	{14, 17, 16, 23, 17, 17, 14}, // g  .###. #...# #.... #.### #...# #...# .###.
+	{17, 17, 17, 31, 17, 17, 17}, // h  #...# #...# #...# ##### #...# #...# #...#
+	{31, 4, 4, 4, 4, 4, 31},      // i  ##### ..#.. ..#.. ..#.. ..#.. ..#.. #####
+	{15, 1, 1, 1, 17, 17, 14},    // j  .#### ....# ....# ....# #...# #...# .###.
+	{17, 18, 20, 24, 20, 18, 17}, // k  #...# #..#. #.#.. ##... #.#.. #..#. #...#
+	{16, 16, 16, 16, 16, 16, 31}, // l  #.... #.... #.... #.... #.... #.... #####
+	{17, 27, 21, 17, 17, 17, 17}, // m  #...# ##.## #.#.# #...# #...# #...# #...#
+	{17, 25, 21, 19, 17, 17, 17}, // n  #...# ##..# #.#.# #..## #...# #...# #...#
+	{14, 17, 17, 17, 17, 17, 14}, // o  .###. #...# #...# #...# #...# #...# .###.
+	{30, 17, 17, 30, 16, 16, 16}, // p  ####. #...# #...# ####. #.... #.... #....
+	{14, 17, 17, 17, 21, 18, 13}, // q  .###. #...# #...# #...# #.#.# #..#. .##.#
+	{30, 17, 17, 30, 20, 18, 17}, // r  ####. #...# #...# ####. #.#.. #..#. #...#
+	{15, 16, 16, 14, 1, 1, 30},   // s  .#### #.... #.... .###. ....# ....# ####.
+	{31, 4, 4, 4, 4, 4, 4},       // t  ##### ..#.. ..#.. ..#.. ..#.. ..#.. ..#..
+	{17, 17, 17, 17, 17, 17, 14}, // u  #...# #...# #...# #...# #...# #...# .###.
+	{17, 17, 17, 17, 10, 10, 4},  // v  #...# #...# #...# #...# .#.#. .#.#. ..#..
+	{17, 17, 17, 17, 21, 27, 17}, // w  #...# #...# #...# #...# #.#.# ##.## #...#
+	{17, 10, 10, 4, 10, 10, 17},  // x  #...# .#.#. .#.#. ..#.. .#.#. .#.#. #...#
+	{17, 17, 10, 4, 4, 4, 4},     // y  #...# #...# .#.#. ..#.. ..#.. ..#.. ..#..
+	{31, 1, 2, 4, 8, 16, 31},     // z  ##### ....# ...#. ..#.. .#... #.... #####
+}

--- a/examples/tiled_keyboard_with_sound/main.go
+++ b/examples/tiled_keyboard_with_sound/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"tinygo.org/x/tinygba"
+)
+
+func main() {
+	InitTiles()
+	tinygba.EnableSound(7, 7)
+	for {
+		tinygba.WaitForVBlank()
+		Update()
+		DrawTile()
+	}
+}

--- a/sound.go
+++ b/sound.go
@@ -1,0 +1,61 @@
+// Package sound provides access to the Game Boy Advance's sound hardware.
+//
+// Uses Sound Channel 2 (square wave with envelope) for tone generation.
+// Register layouts based on GBATEK: https://problemkaputt.de/gbatek.htm#gbasoundcontroller
+//
+// Example usage:
+//
+//	sound.Enable(7, 7)
+//	sound.PlayNote(1750, 2, 15, 30) // A4 at 440Hz, 50% duty, max volume
+package tinygba
+
+import "device/gba"
+
+// EnableSound enables master sound and configures channel 2 output on both speakers.
+// Volume should be between 0 and 7.
+func EnableSound(leftVolume, rightVolume uint16) {
+	// SOUNDCNT_X bit 7: master sound enable
+	gba.SOUND.CNT_X.Set(1 << 7)
+
+	// SOUNDCNT_L:
+	//   Bits 0-2:   right master volume
+	//   Bits 4-6:   left master volume
+	//   Bits 8-11:  channels 1-4 enable right
+	//   Bits 12-15: channels 1-4 enable left
+	// Enable Sound 2 on both speakers (bit 9 = ch2 right, bit 13 = ch2 left)
+	gba.SOUND.CNT_L.Set(rightVolume | (leftVolume << 4) | (1 << 9) | (1 << 13))
+
+	// SOUNDCNT_H bits 0-1: PSG channel volume ratio (2 = 100%)
+	gba.SOUND.CNT_H.Set(2)
+}
+
+// DisableSound disables master sound.
+func DisableSound() {
+	gba.SOUND.CNT_X.Set(0)
+}
+
+// PlayNote plays a tone on Sound Channel 2.
+//
+// frequency: register value = 2048 - (131072 / hz). E.g. A4 (440Hz) = 1750.
+// duty: wave pattern (0=12.5%, 1=25%, 2=50%, 3=75%).
+// volume: initial envelope volume (0-15).
+// duration: sound length in (64-n)/256s units (1-63), or 0 for continuous.
+func PlayNote(frequency, duty, volume uint16, duration uint8) {
+	// SOUND2CNT_L (0x4000068) - Duty/Length/Envelope (all in one register):
+	//   Bits 0-5:   sound length
+	//   Bits 6-7:   wave duty
+	//   Bits 8-10:  envelope step time (0 = hold volume)
+	//   Bit  11:    envelope direction (0=decrease, 1=increase)
+	//   Bits 12-15: initial volume
+	gba.SOUND2.CNT_L.Set(uint16(duration) | (duty << 6) | (volume << 12))
+
+	// SOUND2CNT_H (0x400006C) - Frequency/Control:
+	//   Bits 0-10: frequency
+	//   Bit  14:   length flag (1=stop when length expires)
+	//   Bit  15:   initial/restart sound
+	if duration > 0 {
+		gba.SOUND2.CNT_H.Set(frequency | (1 << 14) | (1 << 15))
+	} else {
+		gba.SOUND2.CNT_H.Set(frequency | (1 << 15))
+	}
+}

--- a/tiles.go
+++ b/tiles.go
@@ -1,0 +1,192 @@
+// Package tiles provides access to the Game Boy Advance's Mode 0 tile-based
+// background rendering hardware.
+//
+// Mode 0 supports four tiled backgrounds (BG0–BG3). The CPU writes 2-byte
+// tilemap entries only when cell content changes, letting hardware handle
+// all pixel rendering each frame.
+//
+// Register layouts based on GBATEK: https://problemkaputt.de/gbatek.htm#gbavideobgmodescontrol
+//
+// Example usage:
+//
+//	tiles.Configure(tiles.Layer0, tiles.Layer1)
+//	tiles.SetupLayer(tiles.Layer1, 0, 8, tiles.Colors16, tiles.Size32x32, 1)
+//	tiles.SetupLayer(tiles.Layer0, 0, 9, tiles.Colors16, tiles.Size32x32, 0)
+//	tiles.SetPaletteColor(0, 1, tiles.RGB(0, 31, 0)) // palette 0, index 1 = green
+//	tiles.DefineTile4bpp(0, 1, solidTilePixels)
+//	tiles.Fill(8, 0, 0, 30, 20, 1, 0) // fill screen block 8 with tile 1
+package tinygba
+
+import (
+	"device/gba"
+	"runtime/volatile"
+	"unsafe"
+)
+
+// Layer represents a GBA background layer (BG0–BG3).
+type Layer uint8
+
+const (
+	Layer0 Layer = 0 // highest display priority
+	Layer1 Layer = 1
+	Layer2 Layer = 2
+	Layer3 Layer = 3
+)
+
+// ColorMode controls tile color depth.
+type ColorMode uint8
+
+const (
+	Colors16  ColorMode = 0 // 4bpp: 32 bytes/tile, 16 palettes × 16 colors
+	Colors256 ColorMode = 1 // 8bpp: 64 bytes/tile, 1 palette × 256 colors
+)
+
+// MapSize controls tilemap dimensions.
+type MapSize uint8
+
+const (
+	Size32x32 MapSize = 0 // 256×256 px (default; covers GBA screen)
+	Size64x32 MapSize = 1
+	Size32x64 MapSize = 2
+	Size64x64 MapSize = 3
+)
+
+// Memory base addresses for palette RAM and VRAM.
+const (
+	memPAL  uintptr = 0x05000000
+	memVRAM uintptr = 0x06000000
+)
+
+// mem16 returns a pointer to a volatile 16-bit register at the given address.
+// All VRAM and palette RAM writes go through this to prevent optimizer caching.
+func mem16(addr uintptr) *volatile.Register16 {
+	return (*volatile.Register16)(unsafe.Pointer(addr))
+}
+
+// ConfigureLayers sets DISPCNT to Mode 0 and enables the given layers.
+// Must be called instead of (not alongside) machine.Display.ConfigureLayers().
+func ConfigureLayers(layers ...Layer) {
+	// Mode 0: bits 0-2 of DISPCNT are 000 (no need to set them)
+	var bits uint16
+	for _, l := range layers {
+		bits |= 1 << (8 + uint(l))
+	}
+	gba.DISP.DISPCNT.Set(bits)
+}
+
+// SetupLayer configures a background layer by writing its BGxCNT register.
+//
+//   - charBlock:   0–3  — which 16KB VRAM block holds this layer's tile graphics
+//   - screenBlock: 0–31 — which 2KB VRAM block holds this layer's tilemap
+//   - mode:        Colors16 or Colors256
+//   - size:        map dimensions
+//   - priority:    0 (front) to 3 (back)
+func SetupLayer(layer Layer, charBlock, screenBlock uint8, mode ColorMode, size MapSize, priority uint8) {
+	value := uint16(priority) |
+		(uint16(charBlock) << gba.BGCNT_CHAR_BASE_Pos) |
+		(uint16(mode) << gba.BGCNT_COLORS_Pos) |
+		(uint16(screenBlock) << gba.BGCNT_BASE_Pos) |
+		(uint16(size) << gba.BGCNT_SIZE_Pos)
+	switch layer {
+	case Layer0:
+		gba.BGCNT0.CNT.Set(value)
+	case Layer1:
+		gba.BGCNT1.CNT.Set(value)
+	case Layer2:
+		gba.BGCNT2.CNT.Set(value)
+	case Layer3:
+		gba.BGCNT3.CNT.Set(value)
+	}
+}
+
+// SetScroll sets the scroll offset for a layer (writes BGxHOFS / BGxVOFS).
+// Values are masked to 9 bits per the GBA spec.
+func SetScroll(layer Layer, x, y uint16) {
+	x &= 0x1FF
+	y &= 0x1FF
+	switch layer {
+	case Layer0:
+		gba.BG0.HOFS.Set(x)
+		gba.BG0.VOFS.Set(y)
+	case Layer1:
+		gba.BG1.HOFS.Set(x)
+		gba.BG1.VOFS.Set(y)
+	case Layer2:
+		gba.BG2.HOFS.Set(x)
+		gba.BG2.VOFS.Set(y)
+	case Layer3:
+		gba.BG3.HOFS.Set(x)
+		gba.BG3.VOFS.Set(y)
+	}
+}
+
+// RGB constructs a GBA 15-bit color from 0–31 components (R, G, B).
+// Format: bits 0-4 = R, bits 5-9 = G, bits 10-14 = B.
+func RGB(r, g, b uint8) uint16 {
+	return uint16(r) | uint16(g)<<5 | uint16(b)<<10
+}
+
+// SetPaletteColor writes a 15-bit BGR color into background palette RAM.
+// In Colors16 mode: palette 0–15, index 0–15. index 0 = transparent.
+// In Colors256 mode: palette 0, index 0–255. index 0 = transparent.
+func SetPaletteColor(palette, index uint8, color uint16) {
+	addr := memPAL + uintptr(palette)*32 + uintptr(index)*2
+	mem16(addr).Set(color)
+}
+
+// DefineTile4bpp writes a 32-byte 4bpp tile into VRAM.
+//
+//   - charBlock:  0–3
+//   - tileIndex:  0–511 (16KB / 32 bytes = 512 tiles per block)
+//   - pixels:     32 bytes — each byte encodes 2 pixels; lo nibble = left pixel,
+//     hi nibble = right pixel. Pixel value 0 = transparent.
+func DefineTile4bpp(charBlock uint8, tileIndex uint16, pixels [32]byte) {
+	base := memVRAM + uintptr(charBlock)*16384 + uintptr(tileIndex)*32
+	for i := 0; i < 16; i++ {
+		val := uint16(pixels[i*2]) | uint16(pixels[i*2+1])<<8
+		mem16(base + uintptr(i)*2).Set(val)
+	}
+}
+
+// DefineTile8bpp writes a 64-byte 8bpp tile into VRAM.
+//
+//   - charBlock:  0–3
+//   - tileIndex:  0–255 (16KB / 64 bytes = 256 tiles per block)
+//   - pixels:     64 bytes — each byte is one palette index. 0 = transparent.
+func DefineTile8bpp(charBlock uint8, tileIndex uint16, pixels [64]byte) {
+	base := memVRAM + uintptr(charBlock)*16384 + uintptr(tileIndex)*64
+	for i := 0; i < 32; i++ {
+		val := uint16(pixels[i*2]) | uint16(pixels[i*2+1])<<8
+		mem16(base + uintptr(i)*2).Set(val)
+	}
+}
+
+// SetTile writes one 2-byte tilemap entry at tile coordinates (x, y).
+//
+//   - screenBlock: 0–31
+//   - x, y:        0–31 (tile coordinates within a 32×32 map)
+//   - tileIndex:   0–1023
+//   - palette:     0–15 (Colors16 only; ignored for Colors256)
+//   - flipH, flipV: mirror the tile horizontally/vertically
+func SetTile(screenBlock uint8, x, y uint8, tileIndex uint16, palette uint8, flipH, flipV bool) {
+	addr := memVRAM + uintptr(screenBlock)*2048 + (uintptr(y)*32+uintptr(x))*2
+	entry := tileIndex
+	if flipH {
+		entry |= 1 << 10
+	}
+	if flipV {
+		entry |= 1 << 11
+	}
+	entry |= uint16(palette) << 12
+	mem16(addr).Set(entry)
+}
+
+// FillTiled sets a w×h region of a screen block to the same tile entry.
+// Useful for clearing areas or painting solid-color backgrounds.
+func FillTiled(screenBlock uint8, x, y, w, h uint8, tileIndex uint16, palette uint8) {
+	for row := uint8(0); row < h; row++ {
+		for col := uint8(0); col < w; col++ {
+			SetTile(screenBlock, x+col, y+row, tileIndex, palette, false, false)
+		}
+	}
+}


### PR DESCRIPTION
As a side project I previously built a Wordle style game https://alphabeticle.xyz - and wanted to port it to the GBA using tinygo.

For this I needed proper tilemap support + basic sound, so I implemented support for them in my own private repo.

Thought others may benefit from this, so upstreaming here - it's quite opinionated for my specific usecase but hopefully that's still better than nothing.

I've also extracted a simple keyboard component, that plays beeps and demonstrates how tiling works as an example.